### PR TITLE
added `TZ` env var into command_env

### DIFF
--- a/lib/libreconv.rb
+++ b/lib/libreconv.rb
@@ -80,7 +80,7 @@ module Libreconv
 
     # @return [Hash]
     def command_env
-      Hash[%w[HOME PATH LANG LD_LIBRARY_PATH SYSTEMROOT TEMP].map { |k| [k, ENV[k]] }]
+      Hash[%w[HOME PATH LANG LD_LIBRARY_PATH SYSTEMROOT TEMP TZ].map { |k| [k, ENV[k]] }]
     end
 
     # @param [String] tmp_pipe_path


### PR DESCRIPTION
I am using Excel's TODAY() function.
When I convert it to PDF, I am having trouble with it being evaluated in UTC.
I have improved it by making it inherit the TZ environment variable during conversion.