### PR TITLE
allow PDF export options

### DIFF
--- a/lib/libreconv.rb
+++ b/lib/libreconv.rb
@@ -113,7 +113,7 @@ module Libreconv
 
     # @return [String]
     def target_filename
-      File.basename(escaped_source_path, '.*') + '.' + File.basename(@convert_to, ':*')
+      File.basename(escaped_source_path, '.*') + '.' + @convert_to.split(':').first
     end
 
     # @raise [IOError] If soffice headless command line tool not found.

--- a/spec/libreconv/converter_convert_url_spec.rb
+++ b/spec/libreconv/converter_convert_url_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Libreconv::Converter do
   end
 
   def stub_sample_url
-    url = 'http://file-examples.com/wp-content/uploads/2017/02/file-sample_100kB.doc'
+    url = 'http://file-examples.com/wp-content/storage/2017/02/file-sample_100kB.doc'
     redirection = url.sub(/^http:/i, 'https:') + '?a=a&b=b#c'
 
     stub_request(:head, url)


### PR DESCRIPTION
Fixed an error when calling the `Libreconv.convert` method with a pdf export option.

execute with pdf export option example:

```
Libreconv.convert(input_path, output_path, nil, 'pdf:calc_pdf_Export:{"SelectPdfVersion" {"type":"long","value":"15"}}')
```

The current version gives an error message:

```
Libreconv::ConversionFailedError (Conversion failed! Output: "convert /tmp/xxxx.xlsx -> /tmp/d20230530-1-a3mspb/xxxx.pdf using filter : calc_pdf_Export:{\"SelectPdfVersion\":{\"type\":\"long\",\"value\":\"1\"}}", Error: ""):
```

PDF export options is a feature added in the LibreOffice 7.4.
references: 

- https://vmiklos.hu/blog/pdf-convert-to.html
- https://wiki.documentfoundation.org/ReleaseNotes/7.4

